### PR TITLE
Use exit from sys

### DIFF
--- a/forklib/forking.py
+++ b/forklib/forking.py
@@ -4,6 +4,7 @@ import signal
 import logging
 import multiprocessing
 import random
+from sys import exit
 import warnings
 
 from binascii import hexlify


### PR DESCRIPTION
On interrupt, get 
```
NameError: name 'exit' is not defined[T:MainThread] ERROR:asyncio: Exception in callback Loop._read_from_self
handle: <Handle Loop._read_from_self>
Traceback (most recent call last):
  File "uvloop/cbhandles.pyx", line 69, in uvloop.loop.Handle._run
  File "uvloop/loop.pyx", line 326, in uvloop.loop.Loop._read_from_self
  File "uvloop/loop.pyx", line 331, in uvloop.loop.Loop._invoke_signals
  File "uvloop/loop.pyx", line 306, in uvloop.loop.Loop._ceval_process_signals
  File "/Users/nikitin-artem/Developer/forklib/forklib/forking.py", line 86, in <lambda>
    signal.signal(sig, lambda c, *_: exit(c))
NameError: name 'exit' is not defined
```